### PR TITLE
automatic testing with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "3.3"
+  - "2.7"
+# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+install: 
+  - pip install -r requirements.txt --use-mirrors
+# command to run tests, e.g. python setup.py test
+script:  
+  - nosetests 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.3"
+#  - "3.3"
   - "2.7"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ipython


### PR DESCRIPTION
this resolves rossant/ipycache#6

so far, I only enabled python 2.7 because the python3 support is incomplete

To enable it in the main repo, you need to give travis access to your repository.

You might want to add a badge to the `README.md` file by putting the following into the file:

`[![Build Status](https://travis-ci.org/rossant/ipycache.svg?branch=master)](https://travis-ci.org/rossant/ipycache)`
(yields [![Build Status](https://travis-ci.org/rossant/ipycache.svg?branch=master)](https://travis-ci.org/rossant/ipycache))