### PR TITLE
Adding cloudpickle support

### DIFF
--- a/ipycache.py
+++ b/ipycache.py
@@ -37,7 +37,7 @@ if PY3:
     
     exec_ = getattr(builtins, "exec")
 else:
-    import cPickle as pickle
+    import cloudpickle as pickle
     from StringIO import StringIO        
     _iteritems = "iteritems"
 

--- a/ipycache.py
+++ b/ipycache.py
@@ -36,7 +36,7 @@ if PY3:
     
     exec_ = getattr(builtins, "exec")
 else:
-    import pickle
+    import cPickle as pickle
     # cloudpickle
     import imp
     try:

--- a/ipycache.py
+++ b/ipycache.py
@@ -36,16 +36,6 @@ if PY3:
     exec_ = getattr(builtins, "exec")
 else:
     import cPickle as pickle
-    # cloudpickle
-    import imp
-    try:
-        imp.find_module('cloudpickle')
-        foundcloudpickle = True
-    except ImportError:
-        foundcloudpickle = False
-    if foundcloudpickle:
-        import cloudpickle
-        
     from StringIO import StringIO        
     _iteritems = "iteritems"
 
@@ -151,11 +141,7 @@ def save_vars(path, vars_d):
     
     """
     with open(path, 'wb') as f:
-        if foundcloudpickle:
-            cloudpickle.dump(vars_d, f)
-        else:
-            pickle.dump(vars_d, f)
-            
+        pickle.dump(vars_d, f)
     
     
 #------------------------------------------------------------------------------

--- a/ipycache.py
+++ b/ipycache.py
@@ -55,6 +55,15 @@ def iteritems(d, **kw):
     """Return an iterator over the (key, value) pairs of a dictionary."""
     return iter(getattr(d, _iteritems)(**kw))
 
+#------------------------------------------------------------------------------
+# cloudpickle 
+#------------------------------------------------------------------------------
+
+try:
+   import cloudpickle
+   dump = cloudpickle.dump
+except ImportError:
+   dump = pickle.dump
 
 #------------------------------------------------------------------------------
 # Functions
@@ -141,7 +150,7 @@ def save_vars(path, vars_d):
     
     """
     with open(path, 'wb') as f:
-        pickle.dump(vars_d, f)
+        dump(vars_d, f)
     
     
 #------------------------------------------------------------------------------

--- a/ipycache.py
+++ b/ipycache.py
@@ -19,6 +19,8 @@ from IPython.utils.io import CapturedIO, capture_output
 from IPython.display import clear_output
 import hashlib
 
+# dill
+import dill
 
 #------------------------------------------------------------------------------
 # Six utility functions for Python 2/3 compatibility

--- a/ipycache.py
+++ b/ipycache.py
@@ -20,7 +20,6 @@ from IPython.display import clear_output
 import hashlib
 
 
-
 #------------------------------------------------------------------------------
 # Six utility functions for Python 2/3 compatibility
 #------------------------------------------------------------------------------

--- a/ipycache.py
+++ b/ipycache.py
@@ -19,8 +19,8 @@ from IPython.utils.io import CapturedIO, capture_output
 from IPython.display import clear_output
 import hashlib
 
-# dill
-import dill
+# cloudpickle
+import cloudpickle
 
 #------------------------------------------------------------------------------
 # Six utility functions for Python 2/3 compatibility
@@ -37,7 +37,7 @@ if PY3:
     
     exec_ = getattr(builtins, "exec")
 else:
-    import cloudpickle as pickle
+    import pickle
     from StringIO import StringIO        
     _iteritems = "iteritems"
 
@@ -143,7 +143,10 @@ def save_vars(path, vars_d):
     
     """
     with open(path, 'wb') as f:
-        pickle.dump(vars_d, f)
+        try:
+            pickle.dump(vars_d, f)
+        except:
+            cloudpickle.dump(vars_d, f)
     
     
 #------------------------------------------------------------------------------

--- a/ipycache.py
+++ b/ipycache.py
@@ -19,8 +19,7 @@ from IPython.utils.io import CapturedIO, capture_output
 from IPython.display import clear_output
 import hashlib
 
-# cloudpickle
-import cloudpickle
+
 
 #------------------------------------------------------------------------------
 # Six utility functions for Python 2/3 compatibility
@@ -38,6 +37,16 @@ if PY3:
     exec_ = getattr(builtins, "exec")
 else:
     import pickle
+    # cloudpickle
+    import imp
+    try:
+        imp.find_module('cloudpickle')
+        foundcloudpickle = True
+    except ImportError:
+        foundcloudpickle = False
+    if foundcloudpickle:
+        import cloudpickle
+        
     from StringIO import StringIO        
     _iteritems = "iteritems"
 
@@ -143,10 +152,11 @@ def save_vars(path, vars_d):
     
     """
     with open(path, 'wb') as f:
-        try:
-            pickle.dump(vars_d, f)
-        except:
+        if foundcloudpickle:
             cloudpickle.dump(vars_d, f)
+        else:
+            pickle.dump(vars_d, f)
+            
     
     
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Check if the cloudpickle module is installed and use it for dump because cloudpickle can dump things that pickle can't(e.g.lambda functions).