### PR TITLE
IPython.utils.traitlets has moved to a top-level

### DIFF
--- a/ipycache.py
+++ b/ipycache.py
@@ -14,7 +14,7 @@ import inspect, os, sys, textwrap, re
 from IPython.config.configurable import Configurable
 from IPython.core import magic_arguments
 from IPython.core.magic import Magics, magics_class, line_magic, cell_magic
-from IPython.utils.traitlets import Unicode
+from traitlets import Unicode
 from IPython.utils.io import CapturedIO, capture_output
 from IPython.display import clear_output
 import hashlib


### PR DESCRIPTION
to address #37 , however I'm not sure when traitlets moved to toplevel and hence what this change would mean for backwards compatibility to old IPython versions.
