### PR TITLE
Fix GitHub Actions setup and test config

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,9 +10,17 @@ jobs:
   run-tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ 'ubuntu-20.04', 'macos-10.15', 'macos-11' ]
-        python: [ '2.7', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        os: [ 'ubuntu-18.04', 'ubuntu-20.04', 'macos-10.15', 'macos-11' ]
+        # Tests running via `nosetests` on Python 3.10 fail with the error:
+        #
+        #     "AttributeError: module 'collections' has no attribute 'Callable'"
+        # 
+        # Per https://github.com/nose-devs/nose/issues/1099, nose is no longer
+        # maintained and so this will not be fixed; we need to migrate to either
+        # nose2 or pytest, per the discussion on the above issue.
+        python: [ '3.7', '3.8', '3.9' ]
     name: Python ${{ matrix.python }} (${{ matrix.os }})
     steps:
       - name: Checkout repo
@@ -22,11 +30,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+          architecture: x64
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt --use-mirrors
-          pip install -r test_requirements.txt --use-mirrors
+          pip install -r requirements.txt
+          pip install -r test_requirements.txt
 
       - name: Run tests
         run: |


### PR DESCRIPTION
Per the most recent GitHub Actions run, fix the setup and test commands:

* remove `--use-mirrors` flag from the `pip` command as it's no longer a valid
  option [failed pip run](https://github.com/rossant/ipycache/runs/4766646133)
* remove Python 3.3 and 3.4 from the list of versions as they are not available
  on macOS ([failed Python 3.3 install], [failed Python 3.4 install])

The list of [available Python versions] shows Python 3.5 and later are provided.

Minor changes:

* add Ubuntu 18.04 LTS to the list of OS versions in case folks still use
  it, since it's still supported and may be in use
* explicitly specify the `x64` architecture to clarify that we're running in
  64-bit mode (also the default), as opposed to `x86` which would run in 32-bit
  mode

Closes https://github.com/rossant/ipycache/issues/52

[failed pip run]: https://github.com/rossant/ipycache/runs/4766646133
[failed Python 3.3 install]: https://github.com/rossant/ipycache/runs/4766646186
[failed Python 3.4 install]: https://github.com/rossant/ipycache/runs/4766646247
[available Python versions]: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json