### PR TITLE
Update README and add PyPI badge [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,68 @@
-%%cache cell magic
-==================
+# ipycache
 
 [![Build Status][github-ci-badge]][github-ci-url]
+[![Latest PyPI version][pypi-badge]][pypi-url]
 
 [github-ci-badge]: https://github.com/rossant/ipycache/actions/workflows/master.yml/badge.svg
 [github-ci-url]: https://github.com/rossant/ipycache/actions/workflows/master.yml
+[pypi-badge]: https://img.shields.io/pypi/v/ipycache.svg
+[pypi-url]: https://pypi.org/project/ipycache/
 
-Defines a %%cache cell magic in the IPython notebook to cache results and outputs of long-lasting computations in a persistent pickle file. Useful when some computations in a notebook are long and you want to easily save the results in a file.
+Defines a `%%cache` cell magic in the IPython notebook to cache results and
+outputs of long-lasting computations in a persistent pickle file. Useful when
+some computations in a notebook are long and you want to easily save the results
+in a file.
 
-Example
--------
+## Examples
 
-  * [Example notebook](http://nbviewer.ipython.org/urls/raw.github.com/rossant/ipycache/master/examples/example.ipynb).
+* [Sample usage](examples/example.ipynb)
+* [Example with output](examples/example_outputs.ipynb)
+* [Simultaneously printing and capturing output](examples/capture_output.ipynb)
 
+## Installation
 
-Installation
-------------
+Latest PyPI release:
 
-  * `pip install ipycache`
-  * `pip install git+https://github.com/rossant/ipycache.git` (for the latest development version)
+    pip install ipycache
+
+Latest development version:
+
+    pip install git+https://github.com/rossant/ipycache.git
+
+## Usage
   
-Usage
------
-  
-  * In IPython:
-  
-        %load_ext ipycache
-  
-  * Then, create a cell with:
-  
-        %%cache mycache.pkl var1 var2
-        var1 = 1
-        var2 = 2
+In IPython, execute the following:
 
+    %load_ext ipycache
 
-  * When you execute this cell the first time, the code is executed, and the variables `var1` and `var2` are saved in `mycache.pkl` in the current directory along with the outputs. Rich display outputs are only saved if you use the development version of IPython. When you execute this cell again, the code is skipped, the variables are loaded from the file and injected into the namespace, and the outputs are restored in the notebook.
+Then, create a cell with:
 
-  * Alternatively use `$file_name` instead of `mycache.pkl`, where `file_name` is a variable holding the path to the file used for caching.
+    %%cache mycache.pkl var1 var2
+    var1 = 1
+    var2 = 2
 
-  * Use the `--force` or `-f` option to force the cell's execution and overwrite the file.
-  
-  * Use the `--read` or `-r` option to prevent the cell's execution and always load the variables from the cache. An exception is raised if the file does not exist.
-  
-  * Use the `--cachedir` or `-d` option to specify the cache directory. You can specify a default directory in the IPython configuration file in your profile (typically in `~\.ipython\profile_default\ipython_config.py`) by adding the following line:
-  
-        c.CacheMagics.cachedir = "/path/to/mycache"
-  
-    If both a default cache directory and the `--cachedir` option are given, the latter is used.
+When you execute this cell the first time, the code is executed, and the
+variables `var1` and `var2` are saved in `mycache.pkl` in the current directory
+along with the outputs. Rich display outputs are only saved if you use the
+development version of IPython. When you execute this cell again, the code is
+skipped, the variables are loaded from the file and injected into the namespace,
+and the outputs are restored in the notebook.
 
+Alternatively use `$file_name` instead of `mycache.pkl`, where `file_name` is a
+variable holding the path to the file used for caching.
+
+Use the `--force` or `-f` option to force the cell's execution and overwrite the
+file.
+
+Use the `--read` or `-r` option to prevent the cell's execution and always load
+the variables from the cache. An exception is raised if the file does not exist.
+
+Use the `--cachedir` or `-d` option to specify the cache directory. You can
+specify a default directory in the IPython configuration file in your profile
+(typically in `~\.ipython\profile_default\ipython_config.py`) by adding the
+following line:
+
+    c.CacheMagics.cachedir = "/path/to/mycache"
+
+If both a default cache directory and the `--cachedir` option are given, the
+latter is used.


### PR DESCRIPTION
Global changes:

* use leading `#` to specify heading level rather than underlines; it's easier
  to manage and does not require an extra line or keeping the underline matching
  the length of the heading

Initial section:

* update title to be "ipycache" instead of description, since it's already in
  the first line of the README
* add badge displaying the latest PyPI version and linking to PyPI

Installation section:

* put installation commands into separate block commands rather than inline code

Examples section:

* link to all 3 notebooks in the `examples` directory
* link to notebooks using relative links, since GitHub can now render notebooks

Usage section:

* remove bullet points in "Usage" section, since every paragraph was its own
  bullet, and it's not really a list anyway, so it's less readable this way
* replace tabs with spaces for indentation of code