### PR TITLE
Add `text/markdown` README content type in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     url="http://packages.python.org/ipycache",
     py_modules=['ipycache'],
     long_description=read('README.md'),
+    long_description_content_type='text/markdown',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Topic :: Utilities",


### PR DESCRIPTION
Per the [docs], since we're using a Markdown-formatted README, we should provide
its content-type, so that it renders properly on PyPI.

[docs]: https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata