### PR TITLE
Fix setup.py `description` and `url` fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,12 @@ setup(
     version="0.1.5dev",
     author="Cyrille Rossant",
     author_email="rossant@github",
-    description=(("Defines a %%cache cell magic in the IPython notebook to "
-                   "cache results of long-lasting computations in a persistent"
-                   "pickle file.")),
+    description=("Defines a %%cache cell magic in the IPython notebook to "
+                 "cache results of long-lasting computations in a persistent "
+                 "pickle file."),
     license="BSD",
     keywords="ipython notebook cache",
-    url="http://packages.python.org/ipycache",
+    url="https://github.com/rossant/ipycache",
     py_modules=['ipycache'],
     long_description=read('README.md'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
* `description` doesn't need double-parentheses, and add missing space at the
  end of the line that otherwise causes "persistent" and "pickle" to merge into
  a single word
* change `url` to point to the GitHub repo as the current URL forwards to a host
  that's no longer serving anything