### PR TITLE
Clarify license as `BSD-3-Clause` in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=("Defines a %%cache cell magic in the IPython notebook to "
                  "cache results of long-lasting computations in a persistent "
                  "pickle file."),
-    license="BSD",
+    license="BSD-3-Clause",
     keywords="ipython notebook cache",
     url="https://github.com/rossant/ipycache",
     py_modules=['ipycache'],


### PR DESCRIPTION
There are many [BSD-style licenses][1], and while they're all categorized as
"permissive" licenses, it's important to clarify which license this repo has.

This repo's license is [classified by GitHub][2] as:

> BSD 3-Clause "New" or "Revised" License

so this is not a change, as much as a clarification of current state.

[1]: https://en.wikipedia.org/wiki/BSD_licenses
[2]: https://github.com/rossant/ipycache/blob/master/LICENSE.md

Closes https://github.com/rossant/ipycache/issues/41