### PR TITLE
Migrate from `nose` to `nose2`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run tests
         run: |
-          nosetests
+          nose2 -v --pretty-assert
           python setup.py check --metadata --strict
           python ipynb_runner.py -v -s examples/example.ipynb
           python ipynb_runner.py -v -s examples/example_outputs.ipynb

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
 numpy
 matplotlib
+nose2 ~= 0.10.0


### PR DESCRIPTION
As described in [this issue][1] and [our CI config][2], `nose` is deprecated and
unmaintained, and incompatible with Python 3.10 and 3.11, and we need to upgrade
to `nose2` or another solution. We're choosing `nose2` since it's closest to
`nose`, so unless there are critical issues with `nose2` and this codebase, we
should be fine with that approach for now.

Closes https://github.com/rossant/ipycache/issues/61

[1]: https://github.com/rossant/ipycache/issues/61
[2]: https://github.com/rossant/ipycache/blob/ca8a1fb2feb05c85997e3e03eb37fdf70eecdbc0/.github/workflows/master.yml#L16-L23