### PR TITLE
Explicitly install `nose` to unbreak tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,7 +20,7 @@ jobs:
         # Per https://github.com/nose-devs/nose/issues/1099, nose is no longer
         # maintained and so this will not be fixed; we need to migrate to either
         # nose2 or pytest, per the discussion on the above issue.
-        python: [ '3.7', '3.8', '3.9' ]
+        python: [ '2.7', '3.7', '3.8', '3.9' ]
     name: Python ${{ matrix.python }} (${{ matrix.os }})
     steps:
       - name: Checkout repo
@@ -32,15 +32,25 @@ jobs:
           python-version: ${{ matrix.python }}
           architecture: x64
 
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-          pip install -r test_requirements.txt
+      - name: Install core requirements
+        run: pip install -r requirements.txt
 
-      - name: Run tests
+      - name: Install Python 2.7 test requirements
+        if: ${{ matrix.python == '2.7' }}
+        run: pip install -r test_requirements_python27.txt
+
+      - name: Install Python 3 test requirements
+        if: ${{ matrix.python != '2.7' }}
+        run: pip install -r test_requirements.txt
+
+      - name: Run unit tests
+        run: nosetests
+
+      - name: Check setup.py metadata
+        run: python setup.py check --metadata --strict
+
+      - name: Run notebook tests
         run: |
-          nosetests
-          python setup.py check --metadata --strict
           python ipynb_runner.py -v -s examples/example.ipynb
           python ipynb_runner.py -v -s examples/example_outputs.ipynb
           # Removed in https://github.com/rossant/ipycache/commit/632b7732622239cf363e3606f694735818ec6cc6

--- a/ipynb_runner.py
+++ b/ipynb_runner.py
@@ -2,8 +2,8 @@
 Script for running ipython notebooks.
 """
 from __future__ import print_function
-from IPython.nbformat.current import read
-from IPython.kernel import KernelManager
+from nbformat import read
+from jupyter_client.manager import KernelManager
 import argparse
 #from pprint import pprint
 import sys
@@ -38,7 +38,7 @@ notebook = '{name}{ext}'.format(name=args.notebook, ext=''
 if args.verbose:
     print('Checking: {}'.format(notebook))
 
-nb = read(open(notebook), 'json')
+nb = read(open(notebook), as_version=3)
 
 # starting up kernel
 km = KernelManager()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ipython[all]
+ipython < 8.0.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,9 @@
+# Note: this file can only be used in a Python 3 environment; for Python 2.7,
+# use test_requirements_python27.txt instead.
+
 numpy
 matplotlib
+nbformat ~= 5.1.3
+nose == 1.3.7
+jupyter-client ~= 7.1.1
+ipykernel ~= 6.7.0

--- a/test_requirements_python27.txt
+++ b/test_requirements_python27.txt
@@ -1,0 +1,9 @@
+# Note: this file can only be used in a Python 2.7 environment; for Python 3,
+# use test_requirements.txt instead.
+
+numpy
+matplotlib
+nbformat ~= 4.4.0
+nose == 1.3.7
+jupyter-client ~= 5.3.5
+ipykernel ~= 4.10.1


### PR DESCRIPTION
The command `nosetests` appears to have disappeared from the GitHub Actions
images for Python 3.8 and 3.9 on all versions of Ubuntu and macOS, so let's try
installing it manually to fix the tests in the short-term.

Closes https://github.com/rossant/ipycache/issues/63