### PR TITLE
Format with autopep8 and clean up code

### DIFF
--- a/ipynb_runner.py
+++ b/ipynb_runner.py
@@ -1,26 +1,30 @@
 """
-Script for running ipython notebooks.
+Script for running IPython notebooks.
 """
+
 from __future__ import print_function
-from nbformat import read
-from jupyter_client.manager import KernelManager
+
 import argparse
-#from pprint import pprint
 import sys
 
+from jupyter_client.manager import KernelManager
+import nbformat
+
+
 def get_ncells(nb):
-    # return number of code cells in a notebook
-    ncells=0
+    """Return number of code cells in a notebook."""
+    ncells = 0
     for ws in nb.worksheets:
         for cell in ws.cells:
-            if cell.cell_type=="code":
-                ncells+=1
+            if cell.cell_type == "code":
+                ncells += 1
     return ncells
-        
+
+
 # input arguments parsing
 parser = argparse.ArgumentParser(description="Run an IPython Notebook")
-parser.add_argument("notebook", 
-                    type=str, 
+parser.add_argument("notebook",
+                    type=str,
                     help='notebook to run')
 parser.add_argument("-v", "--verbose", help="increase output verbosity",
                     action="store_true")
@@ -38,7 +42,7 @@ notebook = '{name}{ext}'.format(name=args.notebook, ext=''
 if args.verbose:
     print('Checking: {}'.format(notebook))
 
-nb = read(open(notebook), as_version=3)
+nb = nbformat.read(open(notebook), as_version=3)
 
 # starting up kernel
 km = KernelManager()
@@ -46,50 +50,50 @@ km.start_kernel()
 kc = km.client()
 kc.start_channels()
 kc.wait_for_ready()
-shell=kc.shell_channel
+shell = kc.shell_channel
 
-ncells=get_ncells(nb)
+ncells = get_ncells(nb)
 
-nerrors=0 # accumulate number of errors
-nsucc=0
+nerrors = 0  # accumulate number of errors
+nsucc = 0
 
 # loop over cells
-icell=1
+icell = 1
 for ws in nb.worksheets:
     for cell in ws.cells:
         if cell.cell_type == 'code':
             if args.verbose:
-                print("Cell:%i/%i> "%(icell,ncells), end=" ")
-            icell+=1
+                print("Cell:%i/%i> " % (icell, ncells), end=" ")
+            icell += 1
             kc.execute(cell.input)
-            msg=kc.get_shell_msg()
-            status=msg['content']['status']            
+            msg = kc.get_shell_msg()
+            status = msg['content']['status']
             if args.verbose:
-                print( status )
-            if status=='ok':
-                nsucc+=1
+                print(status)
+            if status == 'ok':
+                nsucc += 1
                 continue
-            nerrors+=1
+            nerrors += 1
             if args.verbose:
-                print( "="*80 )
-                print( msg['content']['ename'], ":", msg['content']['evalue'] )
-                print( "{0:-^80}".format("<CODE>") )
-                print( cell.input )
-                print( "{0:-^80}".format("</CODE>") )
+                print("=" * 80)
+                print(msg['content']['ename'], ":", msg['content']['evalue'])
+                print("{0:-^80}".format("<CODE>"))
+                print(cell.input)
+                print("{0:-^80}".format("</CODE>"))
                 for m in msg['content']['traceback']:
-                    print( m )
-                print( "="*80 )
+                    print(m)
+                print("=" * 80)
             if args.break_at_error:
                 break
-            
+
 if args.summary:
-    print( "{0:#^80}".format(" Summary: %s "%args.notebook) )
-    print( "Num Errors   : ", nerrors )
-    print(  "Num Successes: ", nsucc )
-    print( "Num Cells    :  ", ncells )
-    
-            
+    print("{0:#^80}".format(" Summary: %s " % args.notebook))
+    print("Num Errors   : ", nerrors)
+    print("Num Successes: ", nsucc)
+    print("Num Cells    :  ", ncells)
+
+
 # kernel cleanup
 kc.stop_channels()
 km.shutdown_kernel(now=True)
-sys.exit(-1 if nerrors>0 else 0)
+sys.exit(-1 if nerrors > 0 else 0)

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,15 @@
 import os
 from setuptools import setup
 
-# Utility function to read the README file.
-# Used for the long_description.  It's nice, because now 1) we have a top level
-# README file and 2) it's easier to type in the README file than to put a raw
-# string in below ...
+
 def read(fname):
+    """Utility function to read the README file.
+
+    Used for long_description. It's nice, because now (1) we have a top level
+    README file and (2) it's easier to type in the README file than to put a raw
+    string in below."""
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
 
 setup(
     name="ipycache",
@@ -29,4 +32,3 @@ setup(
         "License :: OSI Approved :: BSD License",
     ],
 )
-

--- a/test_ipycache.py
+++ b/test_ipycache.py
@@ -2,11 +2,14 @@
 """Tests for ipycache.
 """
 
-#------------------------------------------------------------------------------
-# Imports
-#------------------------------------------------------------------------------
+import hashlib
 import os
+import pickle
 import sys
+
+from ipycache import (save_vars, load_vars, clean_var, clean_vars, do_save,
+                      cache, exec_, conditional_eval)
+from nose.tools import raises, assert_raises
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
@@ -15,37 +18,34 @@ if PY2:
     from cStringIO import StringIO
 else:
     from io import StringIO
-    
-from nose.tools import raises, assert_raises
-from ipycache import (save_vars, load_vars, clean_var, clean_vars, do_save, 
-    cache, exec_, conditional_eval)
-import hashlib
-import pickle
 
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Functions tests
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def test_conditional_eval():
     test_var = 'abc'
     assert conditional_eval('$test_var', locals()) == 'abc'
-    x,fun=10,lambda x: x
-    test_eval='abc_{"10" if x==10 else "not_10"}_{fun(10)}'
-    expect='abc_10_10'
-    assert conditional_eval(test_eval, locals())==expect
-                             
+    x, fun = 10, lambda x: x
+    test_eval = 'abc_{"10" if x==10 else "not_10"}_{fun(10)}'
+    expect = 'abc_10_10'
+    assert conditional_eval(test_eval, locals()) == expect
+
+
 def test_clean_var():
     assert clean_var('abc') == 'abc'
     assert clean_var('abc ') == 'abc'
     assert clean_var('abc,') == 'abc'
     assert clean_var(',abc') == 'abc'
-    
+
+
 def test_clean_vars():
     assert clean_vars(['abc', 'abc,']) == ['abc'] * 2
 
+
 def test_do_save():
     path = 'myvars.pkl'
-    
+
     # File exists.
     open(path, 'wb').close()
     assert_raises(ValueError, do_save, path, force=True, read=True)
@@ -53,17 +53,19 @@ def test_do_save():
     assert not do_save(path, force=False, read=False)
     assert not do_save(path, force=False, read=True)
     os.remove(path)
-    
+
     # File does not exist.
     assert_raises(ValueError, do_save, path, force=True, read=True)
     assert do_save(path, force=True, read=False)
     assert do_save(path, force=False, read=False)
     assert not do_save(path, force=False, read=True)
-    
+
+
 @raises(IOError)
 def test_load_fail():
     path = 'myvars.pkl'
     load_vars(path, ['a', 'b'])
+
 
 def test_save_load():
     path = 'myvars.pkl'
@@ -71,28 +73,29 @@ def test_save_load():
     save_vars(path, vars)
     vars2 = load_vars(path, list(vars.keys()))
     assert vars == vars2
-    
-    os.remove(path)
-    
 
-#------------------------------------------------------------------------------
+    os.remove(path)
+
+
+# ------------------------------------------------------------------------------
 # Cache magic tests
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def test_cache_1():
     path = 'myvars.pkl'
     cell = """a = 1"""
-    
+
     user_ns = {}
+
     def ip_run_cell(cell):
         exec_(cell, {}, user_ns)
-    
+
     def ip_push(vars):
         user_ns.update(vars)
-    
+
     cache(cell, path, vars=['a'], force=False, read=False,
           ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
     assert user_ns['a'] == 1
-    
+
     # We modify the variable in the namespace,
     user_ns['a'] = 2
     # and execute the cell again. The value should be loaded from the pickle
@@ -106,18 +109,18 @@ def test_cache_1():
     cache("""a = 2""", path, vars=['a'], force=False, read=False,
           ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
     assert user_ns['a'] == 2
-     
-    #store 1 again
-    user_ns['a'] = 1 
+
+    # store 1 again
+    user_ns['a'] = 1
     cache("""a = 1""", path, vars=['a'], force=False, read=False,
           ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-    #hack the md5 so code change does not retrigger
+    # hack the md5 so code change does not retrigger
     with open(path, 'rb') as op:
         data = pickle.load(op)
     data['_cell_md5'] = hashlib.md5("""a = 2""".encode()).hexdigest()
     with open(path, 'wb') as op:
         pickle.dump(data, op)
-    #ensure we don't rerun
+    # ensure we don't rerun
     user_ns['a'] = 2
     # and execute the cell again. The value should be loaded from the pickle
     # file. Note how we did not change cell contents
@@ -129,50 +132,54 @@ def test_cache_1():
     cache("""a = 2""", path, vars=['a'], force=True, read=False,
           ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
     assert user_ns['a'] == 2
-    
+
     # Now, we prevent the cell's execution.
     user_ns['a'] = 0
     cache("""a = 3""", path, vars=['a'], force=False, read=True,
           ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
     assert user_ns['a'] == 2
-    
+
     os.remove(path)
-    
+
+
 def test_cache_exception():
     """Check that, if an exception is raised during the cell's execution,
     the pickle file is not written."""
     path = 'myvars.pkl'
     cell = """a = 1;b = 1/0"""
-    
+
     user_ns = {}
+
     def ip_run_cell(cell):
         exec_(cell, {}, user_ns)
-    
+
     def ip_push(vars):
         user_ns.update(vars)
-    
+
     cache(cell, path, vars=['a'], force=False, read=False,
           ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
     assert user_ns['a'] == 1
 
     assert not os.path.exists(path), os.remove(path)
-    
+
+
 def test_cache_outputs():
     """Test the capture of stdout."""
     path = 'myvars.pkl'
     cell = """a = 1;print(a+1)"""
-    
+
     user_ns = {}
+
     def ip_run_cell(cell):
         exec_(cell, {}, user_ns)
-    
+
     def ip_push(vars):
         user_ns.update(vars)
-    
+
     cache(cell, path, vars=['a'], verbose=False,
           ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
     assert user_ns['a'] == 1
-    
+
     # Capture stdout.
     old_stdout = sys.stdout
     sys.stdout = mystdout = StringIO()
@@ -181,28 +188,30 @@ def test_cache_outputs():
     cache(cell, path, vars=['a'], verbose=False,
           ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
     assert user_ns['a'] == 1
-    
+
     sys.stdout = old_stdout
-    
+
     # Check that stdout contains the print statement of the cached cell.
     assert mystdout.getvalue() == '2\n'
-    
+
     os.remove(path)
+
 
 @raises(ValueError)
 def test_cache_fail_1():
     """Fails when saving inexistent variables."""
     path = 'myvars.pkl'
     cell = """a = 1"""
-    
+
     user_ns = {}
+
     def ip_run_cell(cell):
         exec_(cell, {}, user_ns)
-    
+
     def ip_push(vars):
         user_ns.update(vars)
-    
+
     cache(cell, path, vars=['a', 'b'],
           ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-    
+
     os.remove(path)


### PR DESCRIPTION
Cleanups as follows (no functional changes):

* run `autopep8` on code to standardize formatting
* remove unused and commented-out imports
* use consistent 4-space indent (some code used 3 spaces)
* remove extra blank lines and trailing whitespace
* add missing spaces around `=`
* remove "# Imports" comments: it's obvious that they're imports, and imports
  are always at the top of the file
* order imports as per https://www.python.org/dev/peps/pep-0008/#imports
* sort imports when `autopep8` did not