### PR TITLE
Rewrite unit tests to use Python `unittest`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,14 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-18.04', 'ubuntu-20.04', 'macos-10.15', 'macos-11' ]
-        # Tests running via `nosetests` on Python 3.10 fail with the error:
-        #
-        #     "AttributeError: module 'collections' has no attribute 'Callable'"
-        # 
-        # Per https://github.com/nose-devs/nose/issues/1099, nose is no longer
-        # maintained and so this will not be fixed; we need to migrate to either
-        # nose2 or pytest, per the discussion on the above issue.
-        python: [ '2.7', '3.7', '3.8', '3.9' ]
+        python: [ '2.7', '3.7', '3.8', '3.9', '3.10' ]
     name: Python ${{ matrix.python }} (${{ matrix.os }})
     steps:
       - name: Checkout repo
@@ -44,7 +37,7 @@ jobs:
         run: pip install -r test_requirements.txt
 
       - name: Run unit tests
-        run: nosetests
+        run: python -m unittest discover
 
       - name: Check setup.py metadata
         run: python setup.py check --metadata --strict

--- a/test_ipycache.py
+++ b/test_ipycache.py
@@ -6,10 +6,10 @@ import hashlib
 import os
 import pickle
 import sys
+import unittest
 
 from ipycache import (save_vars, load_vars, clean_var, clean_vars, do_save,
                       cache, exec_, conditional_eval)
-from nose.tools import raises, assert_raises
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
@@ -20,198 +20,197 @@ else:
     from io import StringIO
 
 
-# ------------------------------------------------------------------------------
-# Functions tests
-# ------------------------------------------------------------------------------
-def test_conditional_eval():
-    test_var = 'abc'
-    assert conditional_eval('$test_var', locals()) == 'abc'
-    x, fun = 10, lambda x: x
-    test_eval = 'abc_{"10" if x==10 else "not_10"}_{fun(10)}'
-    expect = 'abc_10_10'
-    assert conditional_eval(test_eval, locals()) == expect
+def removeFile(path):
+    """Remove a file which may or may not exist, without throwing exceptions."""
+    # In Python 3, we can write:
+    #
+    #     with contextlib.suppress(FileNotFoundError):
+    #         os.remove(path)
+    #
+    # but to be compatible with Python 2, we explicitly check + remove.
+    if os.path.exists(path):
+        os.remove(path)
 
 
-def test_clean_var():
-    assert clean_var('abc') == 'abc'
-    assert clean_var('abc ') == 'abc'
-    assert clean_var('abc,') == 'abc'
-    assert clean_var(',abc') == 'abc'
+class FunctionTests(unittest.TestCase):
+
+    def test_conditional_eval(self):
+        test_var = 'abc'
+        self.assertEqual(conditional_eval('$test_var', locals()), 'abc')
+        x, fun = 10, lambda x: x
+        test_eval = 'abc_{"10" if x==10 else "not_10"}_{fun(10)}'
+        expect = 'abc_10_10'
+        self.assertEqual(conditional_eval(test_eval, locals()), expect)
+
+    def test_clean_var(self):
+        self.assertEqual(clean_var('abc'), 'abc')
+        self.assertEqual(clean_var('abc '), 'abc')
+        self.assertEqual(clean_var('abc,'), 'abc')
+        self.assertEqual(clean_var(',abc'), 'abc')
+
+    def test_clean_vars(self):
+        self.assertEqual(clean_vars(['abc', 'abc,']), ['abc'] * 2)
+
+    def test_do_save(self):
+        path = 'myvars.pkl'
+
+        # File exists.
+        open(path, 'wb').close()
+        self.assertRaises(ValueError, do_save, path, force=True, read=True)
+        self.assertTrue(do_save(path, force=True, read=False))
+        self.assertFalse(do_save(path, force=False, read=False))
+        self.assertFalse(do_save(path, force=False, read=True))
+        removeFile(path)
+
+        # File does not exist.
+        self.assertRaises(ValueError, do_save, path, force=True, read=True)
+        self.assertTrue(do_save(path, force=True, read=False))
+        self.assertTrue(do_save(path, force=False, read=False))
+        self.assertFalse(do_save(path, force=False, read=True))
+
+    def test_load_fail(self):
+        path = 'myvars.pkl'
+        self.assertRaises(IOError, load_vars, path, ['a', 'b'])
+
+    def test_save_load(self):
+        path = 'myvars.pkl'
+        vars = {'a': 1, 'b': '2'}
+        save_vars(path, vars)
+        vars2 = load_vars(path, list(vars.keys()))
+        self.assertEqual(vars, vars2)
+        removeFile(path)
 
 
-def test_clean_vars():
-    assert clean_vars(['abc', 'abc,']) == ['abc'] * 2
+class CacheMagicTests(unittest.TestCase):
+    def test_cache_1(self):
+        path = 'myvars.pkl'
+        cell = """a = 1"""
 
+        user_ns = {}
 
-def test_do_save():
-    path = 'myvars.pkl'
+        def ip_run_cell(cell):
+            exec_(cell, {}, user_ns)
 
-    # File exists.
-    open(path, 'wb').close()
-    assert_raises(ValueError, do_save, path, force=True, read=True)
-    assert do_save(path, force=True, read=False)
-    assert not do_save(path, force=False, read=False)
-    assert not do_save(path, force=False, read=True)
-    os.remove(path)
+        def ip_push(vars):
+            user_ns.update(vars)
 
-    # File does not exist.
-    assert_raises(ValueError, do_save, path, force=True, read=True)
-    assert do_save(path, force=True, read=False)
-    assert do_save(path, force=False, read=False)
-    assert not do_save(path, force=False, read=True)
+        cache(cell, path, vars=['a'], force=False, read=False,
+              ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
+        self.assertEqual(user_ns['a'], 1)
 
+        # We modify the variable in the namespace,
+        user_ns['a'] = 2
+        # and execute the cell again. The value should be loaded from the pickle
+        # file. Note how we did not change cell contents
+        cache("""a = 1""", path, vars=['a'], force=False, read=False,
+              ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
+        self.assertEqual(user_ns['a'], 1)
 
-@raises(IOError)
-def test_load_fail():
-    path = 'myvars.pkl'
-    load_vars(path, ['a', 'b'])
+        # changing  the cell will trigger reload
+        # file. Note how we did not change cell contents
+        cache("""a = 2""", path, vars=['a'], force=False, read=False,
+              ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
+        self.assertEqual(user_ns['a'], 2)
 
+        # store 1 again
+        user_ns['a'] = 1
+        cache("""a = 1""", path, vars=['a'], force=False, read=False,
+              ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
+        # hack the md5 so code change does not retrigger
+        with open(path, 'rb') as op:
+            data = pickle.load(op)
+        data['_cell_md5'] = hashlib.md5("""a = 2""".encode()).hexdigest()
+        with open(path, 'wb') as op:
+            pickle.dump(data, op)
+        # ensure we don't rerun
+        user_ns['a'] = 2
+        # and execute the cell again. The value should be loaded from the pickle
+        # file. Note how we did not change cell contents
+        cache("""a = 1""", path, vars=['a'], force=False, read=False,
+              ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
+        self.assertEqual(user_ns['a'], 1)
 
-def test_save_load():
-    path = 'myvars.pkl'
-    vars = {'a': 1, 'b': '2'}
-    save_vars(path, vars)
-    vars2 = load_vars(path, list(vars.keys()))
-    assert vars == vars2
+        # Now, we force the cell's execution.
+        cache("""a = 2""", path, vars=['a'], force=True, read=False,
+              ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
+        self.assertEqual(user_ns['a'], 2)
 
-    os.remove(path)
+        # Now, we prevent the cell's execution.
+        user_ns['a'] = 0
+        cache("""a = 3""", path, vars=['a'], force=False, read=True,
+              ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
+        self.assertEqual(user_ns['a'], 2)
 
+        removeFile(path)
 
-# ------------------------------------------------------------------------------
-# Cache magic tests
-# ------------------------------------------------------------------------------
-def test_cache_1():
-    path = 'myvars.pkl'
-    cell = """a = 1"""
+    def test_cache_exception(self):
+        """Check that, if an exception is raised during the cell's execution,
+        the pickle file is not written."""
+        path = 'myvars.pkl'
+        cell = """a = 1;b = 1/0"""
 
-    user_ns = {}
+        user_ns = {}
 
-    def ip_run_cell(cell):
-        exec_(cell, {}, user_ns)
+        def ip_run_cell(cell):
+            exec_(cell, {}, user_ns)
 
-    def ip_push(vars):
-        user_ns.update(vars)
+        def ip_push(vars):
+            user_ns.update(vars)
 
-    cache(cell, path, vars=['a'], force=False, read=False,
-          ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-    assert user_ns['a'] == 1
+        cache(cell, path, vars=['a'], force=False, read=False,
+              ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
+        self.assertEqual(user_ns['a'], 1)
 
-    # We modify the variable in the namespace,
-    user_ns['a'] = 2
-    # and execute the cell again. The value should be loaded from the pickle
-    # file. Note how we did not change cell contents
-    cache("""a = 1""", path, vars=['a'], force=False, read=False,
-          ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-    assert user_ns['a'] == 1
+        self.assertFalse(os.path.exists(path))
+        removeFile(path)
 
-    # changing  the cell will trigger reload
-    # file. Note how we did not change cell contents
-    cache("""a = 2""", path, vars=['a'], force=False, read=False,
-          ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-    assert user_ns['a'] == 2
+    def test_cache_outputs(self):
+        """Test the capture of stdout."""
+        path = 'myvars.pkl'
+        cell = """a = 1;print(a+1)"""
 
-    # store 1 again
-    user_ns['a'] = 1
-    cache("""a = 1""", path, vars=['a'], force=False, read=False,
-          ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-    # hack the md5 so code change does not retrigger
-    with open(path, 'rb') as op:
-        data = pickle.load(op)
-    data['_cell_md5'] = hashlib.md5("""a = 2""".encode()).hexdigest()
-    with open(path, 'wb') as op:
-        pickle.dump(data, op)
-    # ensure we don't rerun
-    user_ns['a'] = 2
-    # and execute the cell again. The value should be loaded from the pickle
-    # file. Note how we did not change cell contents
-    cache("""a = 1""", path, vars=['a'], force=False, read=False,
-          ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-    assert user_ns['a'] == 1
+        user_ns = {}
 
-    # Now, we force the cell's execution.
-    cache("""a = 2""", path, vars=['a'], force=True, read=False,
-          ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-    assert user_ns['a'] == 2
+        def ip_run_cell(cell):
+            exec_(cell, {}, user_ns)
 
-    # Now, we prevent the cell's execution.
-    user_ns['a'] = 0
-    cache("""a = 3""", path, vars=['a'], force=False, read=True,
-          ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-    assert user_ns['a'] == 2
+        def ip_push(vars):
+            user_ns.update(vars)
 
-    os.remove(path)
+        cache(cell, path, vars=['a'], verbose=False,
+              ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
+        self.assertEqual(user_ns['a'], 1)
 
+        # Capture stdout.
+        old_stdout = sys.stdout
+        sys.stdout = mystdout = StringIO()
 
-def test_cache_exception():
-    """Check that, if an exception is raised during the cell's execution,
-    the pickle file is not written."""
-    path = 'myvars.pkl'
-    cell = """a = 1;b = 1/0"""
+        user_ns = {}
+        cache(cell, path, vars=['a'], verbose=False,
+              ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
+        self.assertEqual(user_ns['a'], 1)
 
-    user_ns = {}
+        sys.stdout = old_stdout
 
-    def ip_run_cell(cell):
-        exec_(cell, {}, user_ns)
+        # Check that stdout contains the print statement of the cached cell.
+        self.assertEqual(mystdout.getvalue(), '2\n')
 
-    def ip_push(vars):
-        user_ns.update(vars)
+        removeFile(path)
 
-    cache(cell, path, vars=['a'], force=False, read=False,
-          ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-    assert user_ns['a'] == 1
+    def test_cache_fail_1(self):
+        """Fails when saving nonexistent variables."""
+        path = 'myvars.pkl'
+        cell = """a = 1"""
 
-    assert not os.path.exists(path), os.remove(path)
+        user_ns = {}
 
+        def ip_run_cell(cell):
+            exec_(cell, {}, user_ns)
 
-def test_cache_outputs():
-    """Test the capture of stdout."""
-    path = 'myvars.pkl'
-    cell = """a = 1;print(a+1)"""
+        def ip_push(vars):
+            user_ns.update(vars)
 
-    user_ns = {}
+        self.assertRaises(ValueError, cache, cell, path, vars=['a', 'b'],
+                          ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
 
-    def ip_run_cell(cell):
-        exec_(cell, {}, user_ns)
-
-    def ip_push(vars):
-        user_ns.update(vars)
-
-    cache(cell, path, vars=['a'], verbose=False,
-          ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-    assert user_ns['a'] == 1
-
-    # Capture stdout.
-    old_stdout = sys.stdout
-    sys.stdout = mystdout = StringIO()
-
-    user_ns = {}
-    cache(cell, path, vars=['a'], verbose=False,
-          ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-    assert user_ns['a'] == 1
-
-    sys.stdout = old_stdout
-
-    # Check that stdout contains the print statement of the cached cell.
-    assert mystdout.getvalue() == '2\n'
-
-    os.remove(path)
-
-
-@raises(ValueError)
-def test_cache_fail_1():
-    """Fails when saving inexistent variables."""
-    path = 'myvars.pkl'
-    cell = """a = 1"""
-
-    user_ns = {}
-
-    def ip_run_cell(cell):
-        exec_(cell, {}, user_ns)
-
-    def ip_push(vars):
-        user_ns.update(vars)
-
-    cache(cell, path, vars=['a', 'b'],
-          ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
-
-    os.remove(path)
+        removeFile(path)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,6 +4,5 @@
 numpy
 matplotlib
 nbformat ~= 5.1.3
-nose == 1.3.7
 jupyter-client ~= 7.1.1
 ipykernel ~= 6.7.0

--- a/test_requirements_python27.txt
+++ b/test_requirements_python27.txt
@@ -4,6 +4,5 @@
 numpy
 matplotlib
 nbformat ~= 4.4.0
-nose == 1.3.7
 jupyter-client ~= 5.3.5
 ipykernel ~= 4.10.1


### PR DESCRIPTION
This lets us drop the dependency on the deprecated `nose` library and use the
Python standard library `unittest`. Since we don't use any advanced
functionality, and the `unittest` library is sufficient for our use cases, this
means we can remove the dependency on `nose` without introducing a new
dependency on either `nose2` or `pytest`.

Closes https://github.com/rossant/ipycache/issues/61