### PR TITLE
Set up caching for pip on Linux and macOS

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,6 +25,24 @@ jobs:
           python-version: ${{ matrix.python }}
           architecture: x64
 
+      - name: Set up caching for pip (Linux)
+        uses: actions/cache@v3
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Set up caching for pip (macOS)
+        uses: actions/cache@v3
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install core requirements
         run: pip install -r requirements.txt
 


### PR DESCRIPTION
Implemented per instructions in the [`actions/cache` repo][1].

Closes https://github.com/rossant/ipycache/issues/67

[1]: https://github.com/actions/cache/blob/main/examples.md#python---pip