### PR TITLE
Fix LICENSE copyright, wording, and file extension

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,4 @@
+Copyright (c) 2013-present, ipycache development team
 Copyright (c) 2013, Cyrille Rossant
 All rights reserved.
 
@@ -6,16 +7,16 @@ without modification, are permitted provided that the following
 conditions are met:
 
 * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
+  notice, this list of conditions and the following disclaimer.
 
 * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following
-disclaimer in the documentation and/or other materials provided
-with the distribution.
+  copyright notice, this list of conditions and the following
+  disclaimer in the documentation and/or other materials provided
+  with the distribution.
 
-* Neither the name of border nor the names of its contributors
-may be used to endorse or promote products derived from this
-software without specific prior written permission.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
 CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,


### PR DESCRIPTION
* looked at the git history [1] and found that the first commit by someone
  other than the original author (Cyrille Rossant) was in 2013, so started the
  "team" copyright term from that year
* fixed wording on the license to replace "border" with "copyright holder" as
  this may have been a holdover from another license file
* changed file extension from `.md` to `.txt`

[1]: git log --pretty="format:%an %ad"

Fixes https://github.com/rossant/ipycache/issues/68