### PR TITLE
Removed IPython.utils.io.stdout.

### DIFF
--- a/ipycache.py
+++ b/ipycache.py
@@ -225,7 +225,7 @@ class capture_output_and_print(object):
         stdout = stderr = outputs = None
         if self.stdout:
             #stdout = sys.stdout = StringIO()
-            stdout = sys.stdout = myStringIO(out=IPython.utils.io.stdout)
+            stdout = sys.stdout = myStringIO(out=self.sys_stdout)
         if self.stderr:
             #stderr = sys.stderr = StringIO()
             stderr = sys.stderr = myStringIO(out=self.sys_stderr)


### PR DESCRIPTION
Removed IPython.utils.io.stdout, using sys.stdout instead. It is deprecated and no longer supported since https://github.com/ipython/ipython/commit/da495d08e6a46cf09ead0d69f1658f516045ac77

This fixes issue https://github.com/rossant/ipycache/issues/74